### PR TITLE
add precomputeBlocks to nodes!

### DIFF
--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -1,59 +1,58 @@
 @testset "Constructors" begin
 
-@test_throws ArgumentError NFFTPlan(zeros(1,4), (2,2))
-@test_throws ArgumentError NFFTPlan(zeros(2,4), (2,3))
+  @test_throws ArgumentError NFFTPlan(zeros(1,4), (2,2))
+  @test_throws ArgumentError NFFTPlan(zeros(2,4), (2,3))
 
-p = NFFTPlan(zeros(2,4), (2,2))
-pCopy = copy(p)
+  p = NFFTPlan(zeros(2,4), (2,2))
+  pCopy = copy(p)
 
-for n in fieldnames(typeof(p))
-  println(n)
-  if n ∉ [:tmpVec, :forwardFFT, :backwardFFT, :blocks, :nodesInBlock]
-    @test getfield(p,n) == getfield(pCopy,n)
-  end
-end
-
-@show p
-
-## test range error
-
-
-x = [-0.6  0.9; 0.5  -0.5]
-@test_throws ArgumentError NFFTPlan(x, (2,2))
-x = [-0.3  0.3; 0.3  NaN]
-@test_throws Exception NFFTPlan(x, (2,2))
-# The previous test throws an ArgumentError in the single-threaded case
-# and an TaskFailedException in the multi-threaded case. Needs some rethrow
-
-## test nodes!(p, tr)
-Nx = 32
-trj1 = rand(2, 1000) .- 0.5
-trj2 = rand(2, 1000) .- 0.5
-
-p1 = NFFT.NFFTPlan(trj1, (Nx, Nx))
-p2 = NFFT.NFFTPlan(trj2, (Nx, Nx))
-NFFT.nodes!(p2, trj1)
-
-@test p1.N == p2.N
-@test p1.NOut == p2.NOut
-@test p1.M == p2.M
-@test all(p1.x .== p2.x)
-@test p1.n == p2.n
-@test p1.dims == p2.dims
-for n in fieldnames(typeof(p1.params))
-  @test getfield(p1.params,n) == getfield(p2.params,n)
-end
-@test p1.windowLinInterp == p2.windowLinInterp
-@test p1.windowPolyInterp == p2.windowPolyInterp
-@test p1.windowHatInvLUT == p2.windowHatInvLUT
-@test p1.B == p2.B
-
-for n in fieldnames(typeof(p1.forwardFFT))
+  for n in fieldnames(typeof(p))
     println(n)
-    if n != :pinv
-        @test getfield(p1.forwardFFT,n) == getfield(p1.forwardFFT,n)
-        @test getfield(p1.backwardFFT,n) == getfield(p1.backwardFFT,n)
+    if n ∉ [:tmpVec, :forwardFFT, :backwardFFT, :blocks, :nodesInBlock]
+      @test getfield(p,n) == getfield(pCopy,n)
     end
-end
+  end
 
-end
+  @show p
+
+  ## test range error
+
+
+  x = [-0.6  0.9; 0.5  -0.5]
+  @test_throws ArgumentError NFFTPlan(x, (2,2))
+  x = [-0.3  0.3; 0.3  NaN]
+  @test_throws Exception NFFTPlan(x, (2,2))
+  # The previous test throws an ArgumentError in the single-threaded case
+  # and an TaskFailedException in the multi-threaded case. Needs some rethrow
+
+  ## test nodes!(p, tr)
+  Nx = 32
+  trj1 = rand(2, 1000) .- 0.5
+  trj2 = rand(2, 1000) .- 0.5
+
+  p1 = NFFT.NFFTPlan(trj1, (Nx, Nx))
+  p2 = NFFT.NFFTPlan(trj2, (Nx, Nx))
+  NFFT.nodes!(p2, trj1)
+
+
+  for n in fieldnames(typeof(p1))
+    println(n)
+    if n ∉ [:tmpVec, :forwardFFT, :backwardFFT, :blocks, :nodesInBlock, :params]
+      @test getfield(p1,n) == getfield(p2,n)
+    end
+  end
+
+  for n in fieldnames(typeof(p1.params))
+    println(n)
+    @test getfield(p1.params,n) == getfield(p2.params,n)
+  end
+
+  for n in fieldnames(typeof(p1.forwardFFT))
+      println(n)
+      if n ∉ [:pinv, :plan]
+          @test getfield(p1.forwardFFT,n) == getfield(p2.forwardFFT,n)
+          @test getfield(p1.backwardFFT,n) == getfield(p2.backwardFFT,n)
+      end
+  end
+
+  end


### PR DESCRIPTION
Hi!
I think the function `nodes!` was not fully adopting the new nodes with all the the fancy pre-computation you implemented. I gave it a shot and it seems to work now + I extended the tests to reflect the extra fields. 

Two things I am unsure about:
- `@test p1.params == p2.params` fails while the same test works for `@test p.params == copy(p).params`. However, I can test for the individual fields with `@test getfield(p1.params,n) == getfield(p2.params,n)` and these tests pass.
- the new precomputation seems to slow down the computation by a factor 2x in my use case where I call `nodes!`, calculate one adjoint NFFT and iterate over this. Is there an option for a cheaper pre-calculation at the cost of a slower application of the NFFT?