### PR TITLE
remove hardcoded Float64

### DIFF
--- a/src/precomputation.jl
+++ b/src/precomputation.jl
@@ -10,9 +10,9 @@ function initParams(x::Matrix{T}, N::NTuple{D,Int}, dims::Union{Integer,UnitRang
   params.σ = σ
   params.reltol = reltol
 
-  # Taken from NFFT3 
+  # Taken from NFFT3
   m2K = [1, 3, 7, 9, 14, 17, 20, 23, 24]
-  K = m2K[min(m+1,length(m2K))] 
+  K = m2K[min(m+1,length(m2K))]
   params.LUTSize = 2^(K) * (m+2) # ensure that LUTSize is dividable by (m+2)
 
   if length(dims_) != size(x,1)
@@ -25,8 +25,8 @@ function initParams(x::Matrix{T}, N::NTuple{D,Int}, dims::Union{Integer,UnitRang
 
   doTrafo = ntuple(d->d ∈ dims_, D)
 
-  n = ntuple(d -> doTrafo[d] ? 
-                      (ceil(Int,params.σ*N[d])÷2)*2 : # ensure that n is an even integer 
+  n = ntuple(d -> doTrafo[d] ?
+                      (ceil(Int,params.σ*N[d])÷2)*2 : # ensure that n is an even integer
                         N[d], D)
 
   params.σ = n[dims_[1]] / N[dims_[1]]
@@ -71,7 +71,7 @@ function precomputeB(win, x, N::NTuple{D,Int}, n::NTuple{D,Int}, m, M, σ, K, T)
   return S
 end
 
-@inline @generated function _precomputeB(win, x::AbstractMatrix{T}, N::NTuple{D,Int}, n::NTuple{D,Int}, m, M, 
+@inline @generated function _precomputeB(win, x::AbstractMatrix{T}, N::NTuple{D,Int}, n::NTuple{D,Int}, m, M,
                      σ, scale, I, J, V, mProd, nProd, L::Val{Z}, k, LUTSize) where {T, D, Z}
   quote
 
@@ -96,7 +96,7 @@ end
 
 ### precomputation of the window and the indices required during convolution ###
 
-@generated function precomputeOneNode(win::Function, x::AbstractMatrix{T}, n::NTuple{D,Int}, m, 
+@generated function precomputeOneNode(win::Function, x::AbstractMatrix{T}, n::NTuple{D,Int}, m,
   σ, scale, k, d, L::Val{Z}, LUTSize) where {T,D,Z}
   quote
     xscale = x[d,k] * n[d]
@@ -110,7 +110,7 @@ end
 
 # precompute = LINEAR
 
-@generated function precomputeOneNode(winLin::Array, winPoly::Nothing, x::AbstractMatrix{T}, n::NTuple{D,Int}, m, 
+@generated function precomputeOneNode(winLin::Array, winPoly::Nothing, x::AbstractMatrix{T}, n::NTuple{D,Int}, m,
   σ, scale, k, d, L::Val{Z}, LUTSize) where {T,D,Z}
   quote
     xscale = x[d,k] * n[d]
@@ -126,14 +126,14 @@ end
 
 # precompute = POLYNOMIAL
 
-@generated function precomputeOneNode(winLin::Array, winPoly::NTuple{Y, NTuple{X,T}}, x::AbstractMatrix{T}, n::NTuple{D,Int}, m, 
+@generated function precomputeOneNode(winLin::Array, winPoly::NTuple{Y, NTuple{X,T}}, x::AbstractMatrix{T}, n::NTuple{D,Int}, m,
   σ, scale, k, d, L::Val{Z}, LUTSize) where {Y,X,T,D,Z}
   quote
     xscale = x[d,k] * n[d]
     off = floor(Int, xscale) - m + 1
     tmpIdx = @ntuple $(Z) l -> ( rem(l + off + n[d] - 1, n[d]) + 1)
 
-    idx = (xscale - off - m + 1 - 0.5 )
+    idx = (xscale - off - m + 1//2)
     tmpWin =  shiftedWindowEntries(winPoly, idx, scale, d, L)
 
     return (tmpIdx, tmpWin)
@@ -142,7 +142,7 @@ end
 
 # precompute = LINEAR
 
-function precomputeOneNodeBlocking(winLin, winTensor::Nothing, winPoly::Nothing, 
+function precomputeOneNodeBlocking(winLin, winTensor::Nothing, winPoly::Nothing,
                                     scale, k, d, L, idxInBlock::Matrix)
 
   y, idx = idxInBlock[d,k]
@@ -153,7 +153,7 @@ end
 
 @generated function shiftedWindowEntries(winLin::Vector, idx, scale, d, L::Val{Z}) where {Z}
   quote
-    idxL = floor(Int,idx) 
+    idxL = floor(Int,idx)
     idxInt = Int(idxL)
     α = ( idx-idxL )
 
@@ -167,10 +167,10 @@ end
       # to be part of the abs. The abs is shifting to the positive interval
       # and this +1 matches the `floor` above, which rounds down. In turn
       # for positive and negative indices a different neighbour is calculated
-      idxInt1 = abs( idxInt - (l-1)*scale ) +1 
+      idxInt1 = abs( idxInt - (l-1)*scale ) +1
       idxInt2 = abs( idxInt - (l-1)*scale +1) +1
 
-      (winLin[idxInt1] + α * (winLin[idxInt2] - winLin[idxInt1])) 
+      (winLin[idxInt1] + α * (winLin[idxInt2] - winLin[idxInt1]))
     end
     return tmpWin
   end
@@ -178,7 +178,7 @@ end
 
 # precompute = POLYNOMIAL
 
-function precomputeOneNodeBlocking(winLin, winTensor::Nothing, winPoly::NTuple{Z, NTuple{X,T}}, scale, 
+function precomputeOneNodeBlocking(winLin, winTensor::Nothing, winPoly::NTuple{Z, NTuple{X,T}}, scale,
                                    k, d, L, idxInBlock::Matrix) where {T,Z,X}
 
   y, x = idxInBlock[d,k]
@@ -198,7 +198,7 @@ end
 end
 
 #= Static Array version. Not faster
-function precomputeOneNodeBlocking(winLin, winTensor::Nothing, winPoly::SMatrix{X,Z,T}, scale, 
+function precomputeOneNodeBlocking(winLin, winTensor::Nothing, winPoly::SMatrix{X,Z,T}, scale,
   k, d, L, idxInBlock::Matrix) where {T,Z,X}
 
   y, x = idxInBlock[d,k]
@@ -214,7 +214,7 @@ end
     @nexprs $(X-1) h->(x_{h+1} = x_h * x)
 
     xx = @ntuple $(X) h -> begin
-      x_{h} 
+      x_{h}
     end
 
     xs = SVector(xx...)
@@ -228,7 +228,7 @@ end
 
 # precompute = TENSOR
 
-function precomputeOneNodeBlocking(winLin, winTensor::Array, winPoly::Nothing, scale, 
+function precomputeOneNodeBlocking(winLin, winTensor::Array, winPoly::Nothing, scale,
                                    k, d, L, idxInBlock::Matrix)
   y, idx = idxInBlock[d,k]
   tmpWin =  shiftedWindowEntriesTensor(winTensor, k, d, L)
@@ -253,12 +253,12 @@ end
 """
 Precompute the look up table for the window function φ.
 
-Remarks: 
+Remarks:
 * Only the positive half is computed
 * The window is computed for the interval [0, (m+2)/n]. The reason for the +2 is
-  that we do evaluate the window function outside its interval, since x does not 
+  that we do evaluate the window function outside its interval, since x does not
   necessary match the sampling points
-* The window has K+1 entries and during the index calculation we multiply with the 
+* The window has K+1 entries and during the index calculation we multiply with the
   factor K/(m+2).
 * It is very important that K/(m+2) is an integer since our index calculation exploits
   this fact. We therefore always use `Int(K/(m+2))`instead of `K÷(m+2)` since this gives
@@ -269,7 +269,7 @@ function precomputeLinInterp(win, m, σ, K, T)
 
   step = (m+2) / (K)
   @cthreads for l = 1:(K+1)
-      y = ( (l-1) * step ) 
+      y = ( (l-1) * step )
       windowLinInterp[l] = win(y, 1, m, σ)
   end
   return windowLinInterp
@@ -277,17 +277,17 @@ end
 
 function precomputePolyInterp(win, m, σ, T)
   deg = 2*m # 2*m #+ 2   # Certainly depends on Window
-  K = 2*m 
+  K = 2*m
   NSamples = 2*deg # Sample more densely!!!
   windowPolyInterp = Matrix{T}(undef, deg, K)
 
-  x = range(-0.5, 0.5,length=NSamples) 
+  x = range(-0.5, 0.5,length=NSamples)
   V = ones(deg, NSamples)
   for r=2:deg
     V[r,:] .= V[r-1,:] .* x
   end
 
-  for l = 1:K 
+  for l = 1:K
       y = (-(l-0.5) + m) .+ x
       samples = win.(y, 1, m, σ)
       windowPolyInterp[:,l] .= V' \ samples
@@ -298,7 +298,7 @@ end
 function testPrecomputePoly(win, m, σ, T)
   deg = 2*m + 3
   K = 2*m
-  step = 1 
+  step = 1
 
   windowPolyInterp = precomputePolyInterp(win, m, σ, T)
 
@@ -330,7 +330,7 @@ end
 
 function precomputation(x::Union{Matrix{T},Vector{T}}, N::NTuple{D,Int}, n, params) where {T,D}
 
-  m = params.m; σ = params.σ; window=params.window 
+  m = params.m; σ = params.σ; window=params.window
   LUTSize = params.LUTSize; precompute = params.precompute
 
   win, win_hat = getWindow(window) # highly type instable. But what should be do
@@ -341,7 +341,7 @@ function precomputation(x::Union{Matrix{T},Vector{T}}, N::NTuple{D,Int}, n, para
 
   if params.storeApodizationIdx
     windowHatInvLUT = Vector{Vector{T}}(undef, 1)
-    windowHatInvLUT[1], deconvolveIdx = precompWindowHatInvLUT(params, N, n, windowHatInvLUT_)  
+    windowHatInvLUT[1], deconvolveIdx = precompWindowHatInvLUT(params, N, n, windowHatInvLUT_)
   else
     windowHatInvLUT = windowHatInvLUT_
     deconvolveIdx = Array{Int64,1}(undef, 0)
@@ -365,7 +365,7 @@ function precomputation(x::Union{Matrix{T},Vector{T}}, N::NTuple{D,Int}, n, para
     windowLinInterp = Vector{T}(undef, 0)
     windowPolyInterp = Matrix{T}(undef, 0, 0)
     B = sparse([],[],T[])
-  else 
+  else
     windowLinInterp = Vector{T}(undef, 0)
     windowPolyInterp = Matrix{T}(undef, 0, 0)
     B = sparse([],[],T[])
@@ -380,21 +380,21 @@ end
 
 # This function is type unstable. why???
 function precompWindowHatInvLUT(p::NFFTParams{T}, N, n, windowHatInvLUT_) where {T}
-  
+
   windowHatInvLUT = zeros(Complex{T}, N)
   apodIdx = zeros(Int64, N)
 
   if length(N) == 1
-    precompWindowHatInvLUT(p, windowHatInvLUT, apodIdx, N, n, windowHatInvLUT_, 1) 
+    precompWindowHatInvLUT(p, windowHatInvLUT, apodIdx, N, n, windowHatInvLUT_, 1)
   else
     @cthreads for o = 1:N[end]
-      precompWindowHatInvLUT(p, windowHatInvLUT, apodIdx, N, n, windowHatInvLUT_, o)  
+      precompWindowHatInvLUT(p, windowHatInvLUT, apodIdx, N, n, windowHatInvLUT_, o)
     end
   end
   return vec(windowHatInvLUT), vec(apodIdx)
 end
 
-@generated function precompWindowHatInvLUT(p::NFFTParams{T}, windowHatInvLUT::AbstractArray{Complex{T},D}, 
+@generated function precompWindowHatInvLUT(p::NFFTParams{T}, windowHatInvLUT::AbstractArray{Complex{T},D},
            apodIdx::AbstractArray{Int,D}, N, n, windowHatInvLUT_, o)::Nothing where {D,T}
   quote
     linIdx = LinearIndices(n)
@@ -406,13 +406,13 @@ end
       end begin
       N2 = N[1]÷2
       @inbounds @simd for i = 1:N2
-        apodIdx[i, CartesianIndex(@ntuple $(D-1) l)] = 
+        apodIdx[i, CartesianIndex(@ntuple $(D-1) l)] =
            linIdx[i-N2+n[1], CartesianIndex(@ntuple $(D-1) gidx)]
-        v = windowHatInvLUT_[1][i] 
+        v = windowHatInvLUT_[1][i]
         @nexprs $(D-1) d -> v *= windowHatInvLUT_[d+1][l_d]
         windowHatInvLUT[i, CartesianIndex(@ntuple $(D-1) l)] = v
 
-        apodIdx[i+N2, CartesianIndex(@ntuple $(D-1) l)] = 
+        apodIdx[i+N2, CartesianIndex(@ntuple $(D-1) l)] =
            linIdx[i, CartesianIndex(@ntuple $(D-1) gidx)]
         v = windowHatInvLUT_[1][i+N2]
         @nexprs $(D-1) d -> v *= windowHatInvLUT_[d+1][l_d]
@@ -430,7 +430,7 @@ function precomputeBlocks(x::Matrix{T}, n::NTuple{D,Int}, params, calcBlocks::Bo
   if calcBlocks
     xShift = copy(x)
     shiftNodes!(xShift)
-    blocks, nodesInBlocks, blockOffsets = 
+    blocks, nodesInBlocks, blockOffsets =
         _precomputeBlocks(xShift, n, params.m, params.LUTSize)
 
     idxInBlock =  _precomputeIdxInBlock(xShift, n, params.m, params.precompute, params.LUTSize, blockOffsets, nodesInBlocks)
@@ -448,7 +448,7 @@ function precomputeBlocks(x::Matrix{T}, n::NTuple{D,Int}, params, calcBlocks::Bo
     idxInBlock = Array{Matrix{Tuple{Int,T}},D}(undef, ntuple(d->0,D))
     windowTensor = Array{Array{T,3},D}(undef, ntuple(d->0,D))
   end
-  
+
   return (blocks, nodesInBlocks, blockOffsets, idxInBlock, windowTensor)
 end
 
@@ -480,19 +480,19 @@ function _precomputeBlocks(x::Matrix{T}, n::NTuple{D,Int}, m, LUTSize) where {T,
   blockSize = ntuple(d-> _blockSize(n,d) , D)
   #blockSize = ntuple(d-> n[d] , D) # just one block
   blockSizePadded = ntuple(d-> blockSize[d] + 2*padding[d] , D)
-  
+
   numBlocks =  ntuple(d-> ceil(Int, n[d]/blockSize[d]) , D)
 
   nodesInBlock = [ Int[] for l in CartesianIndices(numBlocks) ]
   numNodesInBlock = zeros(Int, numBlocks)
-  for k=1:size(x,2) # @cthreads 
+  for k=1:size(x,2) # @cthreads
     idx = ntuple(d->unsafe_trunc(Int, x[d,k]*n[d])÷blockSize[d]+1, D)
     numNodesInBlock[idx...] += 1
   end
   @cthreads  for l in CartesianIndices(numBlocks)
     sizehint!(nodesInBlock[l], numNodesInBlock[l])
   end
-  for k=1:size(x,2) # @cthreads  
+  for k=1:size(x,2) # @cthreads
     idx = ntuple(d->unsafe_trunc(Int, x[d,k]*n[d])÷blockSize[d]+1, D)
     push!(nodesInBlock[idx...], k)
   end
@@ -550,7 +550,7 @@ end
 function _precomputeWindowTensor(x::Matrix{T}, n::NTuple{D,Int}, m, σ, nodesInBlock, window::Symbol) where {T,D}
   win, win_hat = getWindow(window) # highly type instable. But what should be do
 
-  return _precomputeWindowTensor(x, n, m, σ, nodesInBlock, win) 
+  return _precomputeWindowTensor(x, n, m, σ, nodesInBlock, win)
 end
 
 function _precomputeWindowTensor(x::Matrix{T}, n::NTuple{D,Int}, m, σ, nodesInBlock, win) where {T,D}
@@ -567,7 +567,7 @@ function _precomputeWindowTensor(x::Matrix{T}, n::NTuple{D,Int}, m, σ, nodesInB
         @inbounds for d=1:D
           xtmp = x[d,k]  # this is expensive because of cache misses
           xscale = xtmp * n[d]
-          #off = unsafe_trunc(Int, xscale) - m 
+          #off = unsafe_trunc(Int, xscale) - m
           off = floor(Int, xscale) - m + 1
 
           @inbounds for k=1:(2*m+1)

--- a/src/precomputation.jl
+++ b/src/precomputation.jl
@@ -133,7 +133,7 @@ end
     off = floor(Int, xscale) - m + 1
     tmpIdx = @ntuple $(Z) l -> ( rem(l + off + n[d] - 1, n[d]) + 1)
 
-    idx = (xscale - off - m + 1//2)
+    idx = (xscale - off - m + T(0.5))
     tmpWin =  shiftedWindowEntries(winPoly, idx, scale, d, L)
 
     return (tmpIdx, tmpWin)


### PR DESCRIPTION
Hi,
the code added a `0.5` which is by default a `Float64` and broke the code when using single precision. I changed this to `1//2` is is a `Rational{Int64}` that gets promoted appropriately to the type of `xscale`. Not sure if this is the best solution, we could also just use `T(0.5)`. Let me know what you prefer or if you know of advantages/disadvantages of one over the other approach. 
-ja