### PR TITLE
CuNFFT plan performance optimization

### DIFF
--- a/CuNFFT/src/implementation.jl
+++ b/CuNFFT/src/implementation.jl
@@ -53,8 +53,8 @@ function CuNFFTPlan(k::Matrix{T}, N::NTuple{D,Int}; dims::Union{Integer,UnitRang
     tmpVecHat .= zero(Complex{T})
 
     deconvIdx = CuArray(deconvolveIdx)
-    winHatInvLUT = CuArray(Complex{T}.(windowHatInvLUT[1])) 
-    B_ = CuSparseMatrixCSC(Complex{T}.(B))
+    winHatInvLUT = CuArray{Complex{T}}(windowHatInvLUT[1]) 
+    B_ = CuSparseMatrixCSC{Complex{T}}(B)
 
     CuNFFTPlan{T,D}(N, NOut, J, k, Ñ, dims_, params, FP, BP, tmpVec, tmpVecHat, 
                deconvIdx, windowLinInterp, winHatInvLUT, B_)


### PR DESCRIPTION
CUDA interally handles the eltype conversion using a `convert` which is more memory efficient, compare e.g.:

```julia
julia> x = Float64[1, 2];

julia> @time Complex{Float64}.(x);
  0.000010 seconds (3 allocations: 144 bytes)

julia> @time convert(Array{Complex{Float32}}, x);
  0.000004 seconds (1 allocation: 80 bytes)
```

so this just uses that. This helped me noticeably with some memory issues for large (2048^2) NFFTs I was having. 