### PR TITLE
Infer arraytype for `plan_nfft` from `k`

### DIFF
--- a/AbstractNFFTs/src/derived.jl
+++ b/AbstractNFFTs/src/derived.jl
@@ -23,6 +23,9 @@ $(planfunc)(k::arrT, N::Union{Integer,NTuple{D,Int}}, args...; kargs...) where {
 $(planfunc)(k::arrT, y::AbstractArray, args...; kargs...) where {arrT <: AbstractArray} =
     $(planfunc)(strip_type_parameters(arrT), k, y, args...; kargs...)
 
+$(planfunc)(k::arrL, args...; kargs...) where {T, arrT <: AbstractArray{T}, arrL <: Union{Adjoint{T, arrT}, Transpose{T, arrT}}} =
+    $(planfunc)(strip_type_parameters(arrT), k, y, args...; kargs...)
+
 # The follow convert 1D parameters into the format required by the plan
 
 $(planfunc)(Q::Type, k::AbstractVector, N::Integer, rest...; kwargs...)  =

--- a/ext/NFFTGPUArraysExt/implementation.jl
+++ b/ext/NFFTGPUArraysExt/implementation.jl
@@ -16,6 +16,8 @@ mutable struct GPU_NFFTPlan{T,D, arrTc <: AbstractGPUArray{Complex{T}, D}, vecI 
   B::SM
 end
 
+# Atm initParams is not supported for k != Array, so in the case of inferred arr from k::GPUArray we need to convert k to Array
+AbstractNFFTs.plan_nfft(arr::Type{<:AbstractGPUArray}, k::AbstractMatrix, args...; kwargs...) = AbstractNFFTs.plan_nfft(arr, Array(k), args...; kwargs...)
 function AbstractNFFTs.plan_nfft(arr::Type{<:AbstractGPUArray}, k::Matrix{T}, N::NTuple{D,Int}, rest...;
   timing::Union{Nothing,TimingStats} = nothing, kargs...) where {T,D}
   t = @elapsed begin

--- a/test/gpu.jl
+++ b/test/gpu.jl
@@ -16,12 +16,18 @@ m = 5
           p = plan_nfft(Array, k, N; m, σ, window, precompute=NFFT.FULL,
             fftflags=FFTW.ESTIMATE)
           p_d = plan_nfft(arrayType, k, N; m, σ, window, precompute=NFFT.FULL)
+          p_d_infer = plan_nfft(arrayType(k), N; m, σ, window, precompute=NFFT.FULL)
           pNDFT = NDFTPlan(k, N)
 
           fHat = rand(Float64, J) + rand(Float64, J) * im
           f = adjoint(pNDFT) * fHat
           fHat_d = arrayType(fHat)
+          
+          # GPU NFFT
           fApprox_d = adjoint(p_d) * fHat_d
+          fApprox_d_infer = adjoint(p_d_infer) * fHat_d
+          @test fApprox_d ≈ fApprox_d_infer
+
           fApprox = Array(fApprox_d)
           e = norm(f[:] - fApprox[:]) / norm(f[:])
           @debug "error adjoint nfft " e
@@ -29,6 +35,8 @@ m = 5
 
           gHat = pNDFT * f
           gHatApprox = Array(p_d * arrayType(f))
+          gHatApproxInfer = Array(p_d_infer * arrayType(f))
+          @test gHatApprox ≈ gHatApproxInfer
           e = norm(gHat[:] - gHatApprox[:]) / norm(gHat[:])
           @debug "error nfft " e
           @test e < eps[l]
@@ -48,6 +56,11 @@ m = 5
       # approximate the density weights
       p = plan_nfft(arrayType, nodes, (N, N); m=5, σ=2.0)
       weights = Array(sdc(p, iters=5))
+
+      # Infer the correct plan_nfft type
+      p_infer = plan_nfft(arrayType(nodes), (N, N); m=5, σ=2.0)
+      weights_infer = Array(sdc(p_infer, iters=5))
+      @test weights ≈ weights_infer
 
       @info extrema(vec(weights))
 


### PR DESCRIPTION
This PR (hopefully) closes #100. The goal of this PR is to seamlessly create either CPU or GPU plans depending on the given argument(s). At the bottom of this comment I'll list some limitations of the current situation of NFFT.jl in regards to this switching.

```julia
k = ...

p_cpu = plan_nfft(k, ...; kwargs...)

using CUDA # or AMDGPU, ...

p_gpu = plan_nfft(CuArray(k), ...; kwargs...)
```

The basic problem of correctly inferring the type is that we need the "base" type of a given array. For example if given a `Array{ComplexF32, 2}` we want `Array` and if given `CuArray{Float32, 2, ...}` we want `CuArray`. We require this base type, since it is needed for `Adapt.jl` to correctly move temporary plan fields to the GPU. At the moment there is no stable API in Julia to achieve this, so we have to use some workaround.

A first option would be to introduce a new function. Since there is no suitable base function we could extend for this case (as far as I know) we have to define our own, for example `plan_type(arr::AbstractArray) = Array`. Then with package extensions we can implement `plan_type(::CuArray{...} = CuArray` and so on. Any array type we don't define, would have to be defined by a user and/or a new PR needs to be made.

The second option is to try to determine the "base" type of a given array using a (not stable) API as described in [here](https://github.com/JuliaLang/julia/issues/35543). The benefit is that this also works without us specifying types for the different GPU backends, but it can break in future Julia versions. Potentially, we would need to support different variants of this function for different Julia versions.

Both approaches are just "best-effort" approaches and there will likely be cases where they fall. For example if `k` is not a dense array but some lazy-wrapped array, for example `adjoint(k)`. In those edge-cases a user still needs to be able to create a fitting plan. For the first option a user could implement their `plan_type`, but since the `plan_type(Array, k, ...; ...)` interface is still available, I feel like this is superfluous and opted to implement the second option.

For convenience I also implemented the inferrence for `adjoint`  and `transpose`. If there are any more common wrappers we want to support we can add them as package extensions.

-------------------------------------------------

With this PR we can chose the correct plan_type based on k. However, at the moment the `initParams` functions in which `k` is used only accepts dense CPU matrices. This means that for the GPU backends, we first infer the type correctly from `k`, then move `k` to the CPU and construct our GPU plan. I think this limitation exceeds the scope of this PR, but it is a little bit counter-intuitive from a user perspective.

Similarly neither our `initParams` nor the inferrence will work with a matrix-free construct like from LinearOperators.jl or LinearMappings.jl.  